### PR TITLE
Updating language-select-button css properties

### DIFF
--- a/components/style.css
+++ b/components/style.css
@@ -90,7 +90,8 @@ hr {
 }
 
 .lang-flag-selected {
-  padding: 0.2em 0em 0em 0em;
+  padding: .1cm;
+  color: #161f2b;
   font-size: 1.8em;
   border-radius: 90px;
   background-color: #d1cec8;

--- a/components/style.css
+++ b/components/style.css
@@ -90,7 +90,7 @@ hr {
 }
 
 .lang-flag-selected {
-  padding: .1cm;
+  padding: .1em;
   color: #161f2b;
   font-size: 1.8em;
   border-radius: 90px;


### PR DESCRIPTION
Heres a suggestion to the open mp language css

to the class .lang-flag-selected

padding: .1em;
color: #161f2b;

I think it looks better.

![CssSuggestion](https://cdn.discordapp.com/attachments/465142687985696788/567811884972244992/cssopenmp.png)