### PR TITLE
Fix language select history

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   plugins: ["react", "prettier"],
   rules: {
     "prettier/prettier": "error",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "import/prefer-default-export": "off"
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     "prettier/prettier": "error",
     "react/prop-types": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "jsx-a11y/anchor-is-valid": "off" // disabled for next.js <Link> usage
   }
 };

--- a/components/LanguageSelect.jsx
+++ b/components/LanguageSelect.jsx
@@ -1,26 +1,31 @@
-import React from 'react';
-import 'flag-icon-css/css/flag-icon.css';
+/* eslint-disable react/no-array-index-key */
+import React from "react";
+import "flag-icon-css/css/flag-icon.css";
 
-export const LanguageSelect = (props) => {
+export const LanguageSelect = ({ flags, selected, callback }) => {
   // no-op for single-language
-  if (props.flags.length === 1) {
+  if (flags.length === 1) {
     return <div />;
   }
 
   return (
     <div className="lang-list">
-      {props.flags.map((value, index, array) => {
+      {flags.map((value, index) => {
         let className = "lang-flag";
-        if (value == props.selected) {
+        if (value === selected) {
           className += " lang-flag-selected";
         }
         return (
-          <a href={`?lang=${value}`} key={index} className={className} onClick={(e) => props.callback(e, value)}>
-            <span className={`flag-icon flag-icon-${value}`}></span>
+          <a
+            href={`?lang=${value}`}
+            key={index}
+            className={className}
+            onClick={e => callback(e, value)}
+          >
+            <span className={`flag-icon flag-icon-${value}`} />
           </a>
         );
       })}
     </div>
   );
 };
-

--- a/components/LanguageSelect.jsx
+++ b/components/LanguageSelect.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/no-array-index-key */
 import React from "react";
+import Link from "next/link";
 import "flag-icon-css/css/flag-icon.css";
 
-export const LanguageSelect = ({ flags, selected, callback }) => {
+const LanguageSelect = ({ flags, selected }) => {
   // no-op for single-language
   if (flags.length === 1) {
-    return <div />;
+    return <div className="lang-list" />;
   }
 
   return (
@@ -16,16 +17,15 @@ export const LanguageSelect = ({ flags, selected, callback }) => {
           className += " lang-flag-selected";
         }
         return (
-          <a
-            href={`?lang=${value}`}
-            key={index}
-            className={className}
-            onClick={e => callback(e, value)}
-          >
-            <span className={`flag-icon flag-icon-${value}`} />
-          </a>
+          <Link href={`?lang=${value}`}>
+            <a key={index} className={className} role="link">
+              <span className={`flag-icon flag-icon-${value}`} />
+            </a>
+          </Link>
         );
       })}
     </div>
   );
 };
+
+export { LanguageSelect };

--- a/components/languages.js
+++ b/components/languages.js
@@ -20,17 +20,14 @@ export const LANGUAGES = {
   ee: "Estonian"
 };
 
-export const loadLanguages = (initial, [language, setLanguage]) => {
-  let currentLanguage = language;
-  if (language === "xx") {
+export const loadLanguages = initial => {
+  let currentLanguage = initial;
+  if (initial === undefined) {
     if (Object.prototype.hasOwnProperty.call(LANGUAGES, initial)) {
       currentLanguage = initial;
     } else {
       currentLanguage = "gb";
     }
-
-    // Store the newly derived initial language.
-    setLanguage(currentLanguage);
   }
 
   // eslint-disable-next-line import/no-dynamic-require
@@ -38,14 +35,10 @@ export const loadLanguages = (initial, [language, setLanguage]) => {
 
   return [
     {
+      name: currentLanguage,
       body: BODY,
       faq: FAQ
     },
-    Object.keys(LANGUAGES),
-    language,
-    (e, l) => {
-      e.preventDefault();
-      setLanguage(l);
-    }
+    Object.keys(LANGUAGES)
   ];
 };

--- a/language/Hungarian.jsx
+++ b/language/Hungarian.jsx
@@ -27,10 +27,10 @@ export const FAQ = () => (
     <p>Az open.mp (Open Multiplayer, OMP) egy többjátékos modifikáció a San Andreas számára ami a SA:MP frissítésével és kezelésével kapcsolatos problémák miatt indult. A kezdeti kiadás csak a szerverfájlok cseréje lesz, és a meglévő SA:MP klienssel rendelkezők csatlakozhatnak ezekhez a szerverekhez. A jövőben egy új open.mp kliens lesz elérhető, amely több érdekes frissítést tesz lehetővé.</p>
     <hr />
     <h2>Ez egy "fork"?</h2>
-    <p>Nem. Ez teljesen nulláról írt, kihasználva az évtizedes tudást és tapasztalatot. A SA:MP-ot megpróbálták korábban újraírni, de úgy gondoljuk ezeknek két fő problémája volt:</p>
+    <p>Nem. Ez a mód teljesen nulláról írt, kihasználva az évtizedes tudást és tapasztalatot. A SA:MP-ot többször is megpróbálták korábban újraírni, de úgy gondoljuk ezeknek két fő problémájuk volt:</p>
     <ol>
       <li>Legtöbbjük a kiszivárgott SA:MP forráskódon alapultak. Ezeknek a modifikációknak a fejlesztői nem rendelkeztek törvényes joggal a kód felhasználásához, és így mindig hátrányos helyzetben voltak, mind morálisan, mind pedig jogilag.</li>
-      <li>Túl sok mindent próbáltak egyszerre elkészíteni. Vagy ki szerették volna cserélni a fejlesztési motort, vagy eltávolítani funkciókat miközben újakat hoznak létre, vagy csak kissebb dolgokat csinálni rossz módon. Ez megakadályozza, hogy a meglévő szerverek hatalmas kódbázisokkal és játékosbázisokkal előre haladjanak, mivel át kell írniuk egy részét, ha nem az egészét a forráskódnak- ami borzasztóan nagy feladat. Az idő múlásával szeretnénk új funkciókat, és további dolgokat is készíteni de legfőképp arra összpontosítunk hogy támogassuk a meglévő szervereket, lehetővé téve számukra hogy saját forráskódjukat ne kelljen megváltoztatniuk.</li>
+      <li>Túl sok mindent próbáltak egyszerre elkészíteni. Vagy ki szerették volna cserélni a fejlesztési motort, vagy eltávolítani funkciókat miközben újakat hoznak létre, vagy csak kissebb dolgokat rosszul csinálni. Ez megakadályozza, hogy a meglévő szerverek hatalmas kódbázisokkal és játékosbázisokkal előre haladjanak, mivel át kell írniuk egy részét, ha nem az egészét a forráskódnak- ami borzasztóan nagy feladat. Az idő múlásával szeretnénk új funkciókat, és további dolgokat is készíteni de legfőképp arra összpontosítunk hogy támogassuk a meglévő szervereket, lehetővé téve számukra hogy saját forráskódjukat ne kelljen gyökeresen megváltoztatniuk.</li>
     </ol>
     <hr />
     <h2>Miért készül ez az egész?</h2>
@@ -42,7 +42,7 @@ export const FAQ = () => (
     <p>Ez a terv, igen. Átmenetileg próbáljuk a fejlesztést kommunikáció és átláthatóság szempontjából nyitottnak titulálni (ami önmagában is javulás), és a jövőben próbálunk a nyílt forráskód felé haladni miután a felhajtás lecsillapult.</p>
     <hr />
     <h2>Hogy tudok segíteni?</h2>
-    <p>Tartsd szemmel a fórumot. Van egy témánk kifejezetten erre a célra ami aktívan frissül ahogy több segítségre lesz szükségünk. Míg a projekt a tervezettnél rövidebb idün belül kiderül, már jó úton vagyunk az első kiadás felé, de ez nem azt jelenti hogy a segítséget nem értékeljük. Előre is köszönjük hogy érdeklődsz, és hiszel a projektben:</p>
+    <p>Tartsd szemmel a fórumot. Van egy témánk kifejezetten erre a célra ami aktívan frissül ahogy több segítségre lesz szükségünk. Míg a projekt a tervezettnél rövidebb idün belül kiderült, már jó úton vagyunk az első kiadás felé, de ez nem azt jelenti hogy a segítséget nem értékeljük. Előre is köszönjük hogy érdeklődsz, és hiszel a projektben:</p>
     <br />
     <a href="https://www.burgershot.gg/showthread.php?tid=99">
       <u>"Hogyan tudsz segíteni" téma(burgershot.gg)</u>

--- a/pages/faq.jsx
+++ b/pages/faq.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { withRouter } from "next/router";
 
@@ -6,24 +6,20 @@ import { HeadContent } from "../components/HeadContent";
 import { loadLanguages } from "../components/languages";
 import Wordmark from "../components/icons/Wordmark";
 
-const Faq = ({ router: { query: initialLang } }) => {
-  const [currentLanguage, flags, selected, callback] = loadLanguages(
-    initialLang,
-    useState("xx")
-  );
+const Faq = ({
+  router: {
+    query: { lang: language }
+  }
+}) => {
+  const [currentLanguage, flags] = loadLanguages(language);
 
   return (
     <div className="container">
-      <HeadContent
-        flags={flags}
-        selected={selected}
-        callback={callback}
-        title="FAQ"
-      />
+      <HeadContent flags={flags} selected={currentLanguage.name} title="FAQ" />
 
       <main>
         <header className="header faq">
-          <Link href={`/index?lang=${selected}`}>
+          <Link href={`/index?lang=${currentLanguage.name}`}>
             <Wordmark
               width={300}
               height="100%"

--- a/pages/faq.jsx
+++ b/pages/faq.jsx
@@ -1,16 +1,13 @@
 import React, { useState } from "react";
 import Link from "next/link";
+import { withRouter } from "next/router";
 
 import { HeadContent } from "../components/HeadContent";
 import { LanguageSelect } from "../components/LanguageSelect";
 import { loadLanguages } from "../components/languages";
 import Wordmark from "../components/icons/Wordmark";
 
-export default ({
-  url: {
-    query: { lang: initialLang }
-  }
-}) => {
+const Faq = ({ router: { query: initialLang } }) => {
   const [currentLanguage, flags, selected, callback] = loadLanguages(
     initialLang,
     useState("xx")
@@ -45,3 +42,5 @@ export default ({
     </div>
   );
 };
+
+export default withRouter(Faq);

--- a/pages/faq.jsx
+++ b/pages/faq.jsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { withRouter } from "next/router";
 
 import { HeadContent } from "../components/HeadContent";
-import { LanguageSelect } from "../components/LanguageSelect";
 import { loadLanguages } from "../components/languages";
 import Wordmark from "../components/icons/Wordmark";
 
@@ -33,7 +32,6 @@ const Faq = ({ router: { query: initialLang } }) => {
             />
           </Link>
         </header>
-        <LanguageSelect flags={flags} selected={selected} callback={callback} />
         <section className="content">
           {currentLanguage.faq()}
           <hr />

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Link from "next/link";
+import { withRouter } from "next/router";
 
 import { HeadContent } from "../components/HeadContent";
 import Wordmark from "../components/icons/Wordmark";
@@ -8,11 +9,7 @@ import Forum from "../components/icons/Forum";
 
 import { loadLanguages } from "../components/languages";
 
-export default ({
-  url: {
-    query: { lang: initialLang }
-  }
-}) => {
+const Index = ({ router: { query: initialLang } }) => {
   const [currentLanguage, flags, selected, callback] = loadLanguages(
     initialLang,
     useState("xx")
@@ -58,3 +55,5 @@ export default ({
     </div>
   );
 };
+
+export default withRouter(Index);

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { withRouter } from "next/router";
 
@@ -9,20 +9,16 @@ import Forum from "../components/icons/Forum";
 
 import { loadLanguages } from "../components/languages";
 
-const Index = ({ router: { query: initialLang } }) => {
-  const [currentLanguage, flags, selected, callback] = loadLanguages(
-    initialLang,
-    useState("xx")
-  );
+const Index = ({
+  router: {
+    query: { lang: language }
+  }
+}) => {
+  const [currentLanguage, flags] = loadLanguages(language);
 
   return (
     <div className="container">
-      <HeadContent
-        flags={flags}
-        selected={selected}
-        callback={callback}
-        title="FAQ"
-      />
+      <HeadContent flags={flags} selected={currentLanguage.name} title="FAQ" />
 
       <main>
         <header className="header">
@@ -35,7 +31,9 @@ const Index = ({ router: { query: initialLang } }) => {
         </header>
         <section className="content">
           {currentLanguage.body(({ children }) => (
-            <Link href={`/faq?lang=${selected}`}>{children}</Link>
+            <Link href={`/faq?lang=${currentLanguage.name}`}>
+              <a>{children}</a>
+            </Link>
           ))}
           <hr />
           <p>


### PR DESCRIPTION
language is now driven entirely via the URL query parameter `lang`, this simplifies a lot of the internals by removing the need to keep the query in sync with the state and mess around with links etc. This is partially an issue with using Next.js, it's slightly overkill for this simple site and I went a bit overboard on the first implementation for this (I should never have introduced local state!). This resolves those issues and vastly simplifies how languages are handled.