### PR TITLE
resolved #65

### DIFF
--- a/components/HeadContent.jsx
+++ b/components/HeadContent.jsx
@@ -8,7 +8,7 @@ const DESC =
   'Open Multiplayer - An upcoming multiplayer mod for Grand Theft Auto: San Andreas that is a fully backwards compatible substitute for SA:MP.';
 
 export const HeadContent = ({ title, ...rest }) => (
-  <div>
+  <div className="menu-content">
     <Head>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/components/style.css
+++ b/components/style.css
@@ -12,7 +12,7 @@ html,
   height: 100%;
   display: grid;
   grid-template-columns: auto 640px auto;
-  grid-template-rows: 1fr 400px 2fr;
+  grid-template-rows: 60px 400px 2fr;
   padding: 0 10px 0 10px;
 }
 
@@ -78,11 +78,16 @@ hr {
   color: #fff;
 }
 
+.menu-content {
+  grid-row: 1 / 3;
+  grid-column: 2 / 3;
+  align-self: start;
+  justify-self: right;
+  z-index: 2;
+}
+
 .lang-list {
   text-align: center;
-  position: absolute;
-  top: 30px;
-  right: 30px;
   padding: 20px;
 }
 
@@ -92,14 +97,11 @@ hr {
   font-size: 35px;
   user-select: none;
   cursor: pointer;
-  width: 55px;
-  height: 35px;
-  border-radius: 20px;
+  border-radius: 10px;
 }
 
 .lang-flag span {
   position: relative;
-  top: -5.5px;
 }
 
 .lang-list:hover .lang-flag,

--- a/components/style.css
+++ b/components/style.css
@@ -80,7 +80,7 @@ hr {
 
 .menu-content {
   grid-row: 1 / 3;
-  grid-column: 2 / 3;
+  grid-column: 1 / 4;
   align-self: start;
   justify-self: right;
   z-index: 2;


### PR DESCRIPTION
Specified the class of the parent div of the head content `.menu-content` so it can be controlled via the grid in `.container`

Added style and grid specification for `.menu-content` so that it is positioned above the main content grid item.

Specified an absolute size for the top-most row to be 60px instead of `auto`, this prevents the row from scaling down to nothing resluting in the language menu intersecting the logo/heading.

Removed some unnecessary rules from `.lang-list` that are no longer needed due to the aforementioned changes.

Also slightly adjusted the style of the language flag buttons with a slightly smaller border radius.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1636971/56456082-38f2f400-635f-11e9-917f-cf0b5af5cc41.png">

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1636971/56456083-401a0200-635f-11e9-9aa3-5d94d12de0e4.png">

<img width="613" alt="image" src="https://user-images.githubusercontent.com/1636971/56456086-54f69580-635f-11e9-93c4-06fa5fbb5b1e.png">
