### PR TITLE
Adjust flag layout to prevent scrollbar

### DIFF
--- a/components/style.css
+++ b/components/style.css
@@ -20,6 +20,10 @@ html,
   .container {
     grid-template-columns: auto 1fr auto;
   }
+
+  .lang-list:hover {
+    background-color: #d1cec8;
+  }
 }
 
 main {
@@ -100,8 +104,11 @@ hr {
 }
 
 .lang-list {
+  display: grid;
   text-align: center;
   padding: 20px;
+  grid-template-columns: 25% 25% 25% 25%;
+  border-radius: 10px;
 }
 
 .lang-flag {

--- a/components/style.css
+++ b/components/style.css
@@ -24,6 +24,10 @@ html,
   .lang-list:hover {
     background-color: #d1cec8;
   }
+
+  .lang-list:hover .lang-flag-selected {
+    border: 1px solid #161f2b;
+  }
 }
 
 main {


### PR DESCRIPTION
Also adds a background colour on smaller screens to prevent text showing through the language menu.

I feel like this makes things a little comfier to look at and prevents us seeing a vertical scrollbar (which bumps the rest of the content) on hover.

### 4 column layout:

![image](https://user-images.githubusercontent.com/1170979/58384044-3a09e780-7fd5-11e9-8cbf-04a17d4b772b.png)

### Background for mobile:

![image](https://user-images.githubusercontent.com/1170979/58384103-d207d100-7fd5-11e9-9799-0f4832ac75fc.png)
