### PR TITLE
Prevent footer from overlapping content

### DIFF
--- a/components/style.css
+++ b/components/style.css
@@ -3,7 +3,6 @@ html,
 #__next {
   margin: 0 0 0 0;
   padding: 0 0 0 0;
-  height: 100%;
   width: 100%;
   background-color: #2d2d2d;
 }


### PR DESCRIPTION
@Southclaws 

Not perfect due to smaller pages now showing the disclaimer directly under content, but better than creating overlap.