### PR TITLE
Use ES6 dynamic import to load blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7022,8 +7022,8 @@
       "version": "github:twopluszero/next-images#158a3198c13f62cab1c0cd5130768aab3d654c18",
       "from": "github:twopluszero/next-images",
       "requires": {
-        "file-loader": "^3.0.1",
-        "url-loader": "^1.1.2"
+        "file-loader": "^5.0.2",
+        "url-loader": "^3.0.0"
       },
       "dependencies": {
         "file-loader": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "prettier": "^1.18.2"
   },
   "eslintConfig": {
+    "root": true,
+    "parser": "babel-eslint",
     "env": {
       "es6": true,
       "node": true

--- a/pages/blog/[slug].jsx
+++ b/pages/blog/[slug].jsx
@@ -1,46 +1,42 @@
-/* eslint-disable global-require */
-
 import React from 'react';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
 import { Content, Paragraph } from '../../components/Typography';
 
-const Post = ({ slug }) => {
-  // eslint-disable-next-line import/no-dynamic-require
-  const post = require(`../../posts/${slug}.mdx`);
+const Post = ({ post }) => (
+  <>
+    <main>
+      <article>
+        <Content>
+          <aside>
+            <Paragraph>
+              Posted {format(parseISO(post.meta.date), 'yyyy-MM-dd')} by {post.meta.author}
+            </Paragraph>
+          </aside>
+          <post.default />
+        </Content>
+      </article>
+    </main>
 
-  return (
-    <>
-      <main>
-        <article>
-          <Content>
-            <aside>
-              <Paragraph>
-                Posted {format(parseISO(post.meta.date), 'yyyy-MM-dd')} by {post.meta.author}
-              </Paragraph>
-            </aside>
-            <post.default />
-          </Content>
-        </article>
-      </main>
+    <style jsx global>
+      {`
+        article {
+          padding: 10px;
+          max-width: 640px;
+          margin: auto;
+        }
+        pre {
+          text-align: left;
+        }
+      `}
+    </style>
+  </>
+);
 
-      <style jsx global>
-        {`
-          article {
-            padding: 10px;
-            max-width: 640px;
-            margin: auto;
-          }
-          pre {
-            text-align: left;
-          }
-        `}
-      </style>
-    </>
-  );
+Post.getInitialProps = async ({ query: { slug } }) => {
+  const post = await import(`../../posts/${slug}.mdx`);
+  return { post };
 };
-
-Post.getInitialProps = ({ query: { slug } }) => ({ slug });
 
 export default Post;


### PR DESCRIPTION
Just wanted to see if it's possible with Next.js. Sadly I wasn't able to figure out a way to do the same for i18n without introducing some per-page boilerplate.

You were also not using babel-eslint as the parser for eslint even though it was installed.