### PR TITLE
Use ES6 dynamic import to load languages

### DIFF
--- a/components/HeadContent.jsx
+++ b/components/HeadContent.jsx
@@ -1,22 +1,28 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Head from 'next/head';
 
 import Nav from './Nav';
+import { LanguageContext } from './languages';
+
 import { Content, Anchor } from './Typography';
 import { Wordmark } from './icons/Brand';
 
-export const HeadContent = ({ title, currentLanguage, flags }) => (
-  <>
-    <Head>
-      <title>Open Multiplayer{title ? ` - ${title}` : ''}</title>
-    </Head>
-    <Content centred>
-      <header>
-        <Anchor href={`/index?lang=${currentLanguage.name}`}>
-          <Wordmark width={300} height="100%" />
-        </Anchor>
-        <Nav currentLanguage={currentLanguage} flags={flags} />
-      </header>
-    </Content>
-  </>
-);
+export const HeadContent = ({ title }) => {
+  const { currentLanguage, flags } = useContext(LanguageContext);
+
+  return (
+    <>
+      <Head>
+        <title>Open Multiplayer{title ? ` - ${title}` : ''}</title>
+      </Head>
+      <Content centred>
+        <header>
+          <Anchor href={`/index?lang=${currentLanguage.name}`}>
+            <Wordmark width={300} height="100%" />
+          </Anchor>
+          <Nav currentLanguage={currentLanguage} flags={flags} />
+        </header>
+      </Content>
+    </>
+  );
+};

--- a/components/HeadContent.jsx
+++ b/components/HeadContent.jsx
@@ -1,14 +1,14 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import Head from 'next/head';
 
 import Nav from './Nav';
-import { LanguageContext } from './languages';
+import { useLanguages } from './languages';
 
 import { Content, Anchor } from './Typography';
 import { Wordmark } from './icons/Brand';
 
 export const HeadContent = ({ title }) => {
-  const { currentLanguage } = useContext(LanguageContext);
+  const { currentLanguage } = useLanguages();
 
   return (
     <>

--- a/components/HeadContent.jsx
+++ b/components/HeadContent.jsx
@@ -4,24 +4,19 @@ import Head from 'next/head';
 import Nav from './Nav';
 import { Content, Anchor } from './Typography';
 import { Wordmark } from './icons/Brand';
-import { useLanguages } from './languages';
 
-export const HeadContent = ({ title }) => {
-  const [language] = useLanguages();
-
-  return (
-    <>
-      <Head>
-        <title>Open Multiplayer{title ? ` - ${title}` : ''}</title>
-      </Head>
-      <Content centred>
-        <header>
-          <Anchor href={`/index?lang=${language.name}`}>
-            <Wordmark width={300} height="100%" />
-          </Anchor>
-          <Nav />
-        </header>
-      </Content>
-    </>
-  );
-};
+export const HeadContent = ({ title, currentLanguage, flags }) => (
+  <>
+    <Head>
+      <title>Open Multiplayer{title ? ` - ${title}` : ''}</title>
+    </Head>
+    <Content centred>
+      <header>
+        <Anchor href={`/index?lang=${currentLanguage.name}`}>
+          <Wordmark width={300} height="100%" />
+        </Anchor>
+        <Nav currentLanguage={currentLanguage} flags={flags} />
+      </header>
+    </Content>
+  </>
+);

--- a/components/HeadContent.jsx
+++ b/components/HeadContent.jsx
@@ -8,7 +8,7 @@ import { Content, Anchor } from './Typography';
 import { Wordmark } from './icons/Brand';
 
 export const HeadContent = ({ title }) => {
-  const { currentLanguage, flags } = useContext(LanguageContext);
+  const { currentLanguage } = useContext(LanguageContext);
 
   return (
     <>
@@ -20,7 +20,7 @@ export const HeadContent = ({ title }) => {
           <Anchor href={`/index?lang=${currentLanguage.name}`}>
             <Wordmark width={300} height="100%" />
           </Anchor>
-          <Nav currentLanguage={currentLanguage} flags={flags} />
+          <Nav />
         </header>
       </Content>
     </>

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -1,61 +1,66 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Anchor } from './Typography';
 import { LanguageSelect } from './LanguageSelect';
+import { LanguageContext } from './languages';
 
-const Nav = ({ currentLanguage, flags }) => (
-  <nav>
-    <ul>
-      <li>
-        <Anchor href={`/?lang=${currentLanguage.name}`}>
-          <span className="button">Home</span>
-        </Anchor>
-      </li>
-      <li>
-        <Anchor href={`/faq?lang=${currentLanguage.name}`}>
-          <span className="button">FAQ</span>
-        </Anchor>
-      </li>
-      <li>
-        <Anchor href={`/progress?lang=${currentLanguage.name}`}>
-          <span className="button">Progress</span>
-        </Anchor>
-      </li>
-      <li>
-        <Anchor href={`/blog?lang=${currentLanguage.name}`}>
-          <span className="button">Blog</span>
-        </Anchor>
-      </li>
-      <li>
-        <LanguageSelect selected={currentLanguage.name} flags={flags}>
-          <span className="button">
-            <span className={`flag-icon flag-icon-${currentLanguage.name}`} />
-          </span>
-        </LanguageSelect>
-      </li>
-    </ul>
+const Nav = () => {
+  const { currentLanguage, flags } = useContext(LanguageContext);
 
-    <style jsx>{`
-      ul {
-        display: flex;
-        list-style: none;
-        padding-left: 0px;
-        justify-content: space-around;
-        align-items: baseline;
-      }
-      li {
-        min-width: 40px;
-        min-height: 2em;
-      }
-      .button {
-        border-radius: 2px;
-        background-color: #3d3d3d;
-        padding: 0.2em 1em 0.2em 1em;
-      }
-      .button:hover {
-        background-color: #8d8d8d;
-      }
-    `}</style>
-  </nav>
-);
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Anchor href={`/?lang=${currentLanguage.name}`}>
+            <span className="button">Home</span>
+          </Anchor>
+        </li>
+        <li>
+          <Anchor href={`/faq?lang=${currentLanguage.name}`}>
+            <span className="button">FAQ</span>
+          </Anchor>
+        </li>
+        <li>
+          <Anchor href={`/progress?lang=${currentLanguage.name}`}>
+            <span className="button">Progress</span>
+          </Anchor>
+        </li>
+        <li>
+          <Anchor href={`/blog?lang=${currentLanguage.name}`}>
+            <span className="button">Blog</span>
+          </Anchor>
+        </li>
+        <li>
+          <LanguageSelect selected={currentLanguage.name} flags={flags}>
+            <span className="button">
+              <span className={`flag-icon flag-icon-${currentLanguage.name}`} />
+            </span>
+          </LanguageSelect>
+        </li>
+      </ul>
+
+      <style jsx>{`
+        ul {
+          display: flex;
+          list-style: none;
+          padding-left: 0px;
+          justify-content: space-around;
+          align-items: baseline;
+        }
+        li {
+          min-width: 40px;
+          min-height: 2em;
+        }
+        .button {
+          border-radius: 2px;
+          background-color: #3d3d3d;
+          padding: 0.2em 1em 0.2em 1em;
+        }
+        .button:hover {
+          background-color: #8d8d8d;
+        }
+      `}</style>
+    </nav>
+  );
+};
 
 export default Nav;

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -1,65 +1,61 @@
 import React from 'react';
 import { Anchor } from './Typography';
-import { useLanguages } from './languages';
 import { LanguageSelect } from './LanguageSelect';
 
-const Nav = () => {
-  const [{ name: lang }, flags] = useLanguages();
-  return (
-    <nav>
-      <ul>
-        <li>
-          <Anchor href={`/?lang=${lang}`}>
-            <span className="button">Home</span>
-          </Anchor>
-        </li>
-        <li>
-          <Anchor href={`/faq?lang=${lang}`}>
-            <span className="button">FAQ</span>
-          </Anchor>
-        </li>
-        <li>
-          <Anchor href={`/progress?lang=${lang}`}>
-            <span className="button">Progress</span>
-          </Anchor>
-        </li>
-        <li>
-          <Anchor href={`/blog?lang=${lang}`}>
-            <span className="button">Blog</span>
-          </Anchor>
-        </li>
-        <li>
-          <LanguageSelect selected={lang} flags={flags}>
-            <span className="button">
-              <span className={`flag-icon flag-icon-${lang}`} />
-            </span>
-          </LanguageSelect>
-        </li>
-      </ul>
+const Nav = ({ currentLanguage, flags }) => (
+  <nav>
+    <ul>
+      <li>
+        <Anchor href={`/?lang=${currentLanguage.name}`}>
+          <span className="button">Home</span>
+        </Anchor>
+      </li>
+      <li>
+        <Anchor href={`/faq?lang=${currentLanguage.name}`}>
+          <span className="button">FAQ</span>
+        </Anchor>
+      </li>
+      <li>
+        <Anchor href={`/progress?lang=${currentLanguage.name}`}>
+          <span className="button">Progress</span>
+        </Anchor>
+      </li>
+      <li>
+        <Anchor href={`/blog?lang=${currentLanguage.name}`}>
+          <span className="button">Blog</span>
+        </Anchor>
+      </li>
+      <li>
+        <LanguageSelect selected={currentLanguage.name} flags={flags}>
+          <span className="button">
+            <span className={`flag-icon flag-icon-${currentLanguage.name}`} />
+          </span>
+        </LanguageSelect>
+      </li>
+    </ul>
 
-      <style jsx>{`
-        ul {
-          display: flex;
-          list-style: none;
-          padding-left: 0px;
-          justify-content: space-around;
-          align-items: baseline;
-        }
-        li {
-          min-width: 40px;
-          min-height: 2em;
-        }
-        .button {
-          border-radius: 2px;
-          background-color: #3d3d3d;
-          padding: 0.2em 1em 0.2em 1em;
-        }
-        .button:hover {
-          background-color: #8d8d8d;
-        }
-      `}</style>
-    </nav>
-  );
-};
+    <style jsx>{`
+      ul {
+        display: flex;
+        list-style: none;
+        padding-left: 0px;
+        justify-content: space-around;
+        align-items: baseline;
+      }
+      li {
+        min-width: 40px;
+        min-height: 2em;
+      }
+      .button {
+        border-radius: 2px;
+        background-color: #3d3d3d;
+        padding: 0.2em 1em 0.2em 1em;
+      }
+      .button:hover {
+        background-color: #8d8d8d;
+      }
+    `}</style>
+  </nav>
+);
 
 export default Nav;

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Anchor } from './Typography';
 import { LanguageSelect } from './LanguageSelect';
-import { LanguageContext } from './languages';
+import { useLanguages } from './languages';
 
 const Nav = () => {
-  const { currentLanguage, flags } = useContext(LanguageContext);
+  const { currentLanguage, flags } = useLanguages();
 
   return (
     <nav>

--- a/components/languages.js
+++ b/components/languages.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-filename-extension */
-import React from 'react';
+import React, { useContext } from 'react';
 
 // These should be in alphabetical order by English name.
 export const LANGUAGES = {
@@ -30,7 +30,9 @@ export const LANGUAGES = {
   vn: ['Vietnamese', 'sans-serif']
 };
 
-export const LanguageContext = React.createContext(null);
+const LanguageContext = React.createContext(null);
+
+export const useLanguages = () => useContext(LanguageContext);
 
 export const withLanguages = (Page) => {
   const WithLanguages = ({ currentLanguage, flags, ...props }) => (

--- a/components/languages.js
+++ b/components/languages.js
@@ -30,8 +30,14 @@ export const LANGUAGES = {
   vn: ['Vietnamese', 'sans-serif']
 };
 
+export const LanguageContext = React.createContext(null);
+
 export const withLanguages = (Page) => {
-  const WithLanguages = (props) => <Page {...props} />;
+  const WithLanguages = ({ currentLanguage, flags, ...props }) => (
+    <LanguageContext.Provider value={{ currentLanguage, flags }}>
+      <Page currentLanguage={currentLanguage} flags={flags} {...props} />
+    </LanguageContext.Provider>
+  );
 
   WithLanguages.getInitialProps = async (context) => {
     const languageFromUrl = context.query.lang;

--- a/components/languages.js
+++ b/components/languages.js
@@ -1,5 +1,5 @@
-/* eslint-disable global-require */
-import { useRouter } from 'next/router';
+/* eslint-disable react/jsx-filename-extension */
+import React from 'react';
 
 // These should be in alphabetical order by English name.
 export const LANGUAGES = {
@@ -30,30 +30,35 @@ export const LANGUAGES = {
   vn: ['Vietnamese', 'sans-serif']
 };
 
-export const useLanguages = () => {
-  const {
-    query: { lang: languageFromUrl }
-  } = useRouter();
+export const withLanguages = (Page) => {
+  const WithLanguages = (props) => <Page {...props} />;
 
-  let currentLanguage = 'gb';
-  if (languageFromUrl && Object.prototype.hasOwnProperty.call(LANGUAGES, languageFromUrl)) {
-    currentLanguage = languageFromUrl;
-  }
+  WithLanguages.getInitialProps = async (context) => {
+    const languageFromUrl = context.query.lang;
 
-  const [name, fontFamily] = LANGUAGES[currentLanguage];
+    const currentLanguage =
+      languageFromUrl && Object.prototype.hasOwnProperty.call(LANGUAGES, languageFromUrl)
+        ? languageFromUrl
+        : 'gb';
 
-  // eslint-disable-next-line import/no-dynamic-require
-  const BODY = require(`../language/${name}/index.mdx`);
-  // eslint-disable-next-line import/no-dynamic-require
-  const FAQ = require(`../language/${name}/faq.mdx`);
+    const [name, fontFamily] = LANGUAGES[currentLanguage];
 
-  return [
-    {
-      name: currentLanguage,
-      fontFamily,
-      body: BODY,
-      faq: FAQ
-    },
-    Object.keys(LANGUAGES).sort()
-  ];
+    const BODY = await import(`../language/${name}/index.mdx`);
+    const FAQ = await import(`../language/${name}/faq.mdx`);
+
+    return {
+      ...(Page.getInitialProps ? await Page.getInitialProps(context) : {}),
+      currentLanguage: {
+        name: currentLanguage,
+        fontFamily,
+        body: BODY,
+        faq: FAQ
+      },
+      flags: Object.keys(LANGUAGES).sort()
+    };
+  };
+
+  WithLanguages.displayName = `WithLanguages(${Page.displayName || Page.name || 'Unknown'})`;
+
+  return WithLanguages;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7026,13 +7026,43 @@
         "url-loader": "^3.0.0"
       },
       "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
         "file-loader": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
-          "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-5.0.2.tgz",
+          "integrity": "sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==",
           "requires": {
-            "loader-utils": "^1.0.2",
-            "schema-utils": "^1.0.0"
+            "loader-utils": "^1.2.3",
+            "schema-utils": "^2.5.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^2.0.0",
+                "json5": "^1.0.1"
+              }
+            }
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
           }
         },
         "mime": {
@@ -7041,23 +7071,52 @@
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         },
         "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.11.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+              "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+              "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+            }
           }
         },
         "url-loader": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-          "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-3.0.0.tgz",
+          "integrity": "sha512-a84JJbIA5xTFTWyjjcPdnsu+41o/SNE8SpXMdUvXs6Q+LuhCD9E2+0VCiuDWqgo3GGXVlFHzArDmBpj9PgWn4A==",
           "requires": {
-            "loader-utils": "^1.1.0",
-            "mime": "^2.0.3",
-            "schema-utils": "^1.0.0"
+            "loader-utils": "^1.2.3",
+            "mime": "^2.4.4",
+            "schema-utils": "^2.5.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^2.0.0",
+                "json5": "^1.0.1"
+              }
+            }
           }
         }
       }

--- a/pages/blog/index.jsx
+++ b/pages/blog/index.jsx
@@ -11,6 +11,8 @@ import {
 } from '../../components/Typography';
 import { HeadContent } from '../../components/HeadContent';
 
+import { withLanguages } from '../../components/languages';
+
 const Posts = ({ list }) =>
   list.map((v) => {
     return (
@@ -31,10 +33,10 @@ const NoContent = () => <h3>There are currently no posts.</h3>;
 
 const PostList = ({ list }) => (list ? <Posts list={list} /> : <NoContent />);
 
-const Page = () => {
+const Page = ({ currentLanguage, flags }) => {
   return (
     <>
-      <HeadContent title="Blog" />
+      <HeadContent flags={flags} currentLanguage={currentLanguage} title="Blog" />
 
       <main>
         <Content>
@@ -48,4 +50,4 @@ const Page = () => {
   );
 };
 
-export default Page;
+export default withLanguages(Page);

--- a/pages/blog/index.jsx
+++ b/pages/blog/index.jsx
@@ -33,21 +33,19 @@ const NoContent = () => <h3>There are currently no posts.</h3>;
 
 const PostList = ({ list }) => (list ? <Posts list={list} /> : <NoContent />);
 
-const Page = ({ currentLanguage, flags }) => {
-  return (
-    <>
-      <HeadContent flags={flags} currentLanguage={currentLanguage} title="Blog" />
+const Page = () => (
+  <>
+    <HeadContent title="Blog" />
 
-      <main>
-        <Content>
-          <article>
-            <HeadingLarge>Development Blog</HeadingLarge>
-            <PostList list={process.env.BLOG_POST_LIST} />
-          </article>
-        </Content>
-      </main>
-    </>
-  );
-};
+    <main>
+      <Content>
+        <article>
+          <HeadingLarge>Development Blog</HeadingLarge>
+          <PostList list={process.env.BLOG_POST_LIST} />
+        </article>
+      </Content>
+    </main>
+  </>
+);
 
 export default withLanguages(Page);

--- a/pages/faq.jsx
+++ b/pages/faq.jsx
@@ -1,22 +1,20 @@
 import React from 'react';
 
 import { HeadContent } from '../components/HeadContent';
-import { useLanguages } from '../components/languages';
 
-const Faq = () => {
-  const [currentLanguage, flags] = useLanguages();
-  return (
-    <div className="container">
-      <HeadContent flags={flags} selected={currentLanguage.name} title="FAQ" />
+import { withLanguages } from '../components/languages';
 
-      <main>
-        <section>
-          <currentLanguage.faq.default />
-          <hr />
-        </section>
-      </main>
-    </div>
-  );
-};
+const Faq = ({ currentLanguage, flags }) => (
+  <div className="container">
+    <HeadContent flags={flags} currentLanguage={currentLanguage} title="FAQ" />
 
-export default Faq;
+    <main>
+      <section>
+        <currentLanguage.faq.default />
+        <hr />
+      </section>
+    </main>
+  </div>
+);
+
+export default withLanguages(Faq);

--- a/pages/faq.jsx
+++ b/pages/faq.jsx
@@ -4,9 +4,9 @@ import { HeadContent } from '../components/HeadContent';
 
 import { withLanguages } from '../components/languages';
 
-const Faq = ({ currentLanguage, flags }) => (
+const Faq = ({ currentLanguage }) => (
   <div className="container">
-    <HeadContent flags={flags} currentLanguage={currentLanguage} title="FAQ" />
+    <HeadContent title="FAQ" />
 
     <main>
       <section>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -7,9 +7,9 @@ import BigLogo from '../components/BigLogo';
 
 import { withLanguages } from '../components/languages';
 
-const Index = ({ currentLanguage, flags }) => (
+const Index = ({ currentLanguage }) => (
   <div>
-    <HeadContent currentLanguage={currentLanguage} flags={flags} title="Homepage" />
+    <HeadContent title="Homepage" />
     <main>
       <section>
         <currentLanguage.body.default />

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -5,30 +5,26 @@ import { Content } from '../components/Typography';
 import Socials from '../components/Socials';
 import BigLogo from '../components/BigLogo';
 
-import { useLanguages } from '../components/languages';
+import { withLanguages } from '../components/languages';
 
-const Index = () => {
-  const [currentLanguage, flags] = useLanguages();
+const Index = ({ currentLanguage, flags }) => (
+  <div>
+    <HeadContent currentLanguage={currentLanguage} flags={flags} title="Homepage" />
+    <main>
+      <section>
+        <currentLanguage.body.default />
 
-  return (
-    <div>
-      <HeadContent flags={flags} selected={currentLanguage.name} title="Homepage" />
-      <main>
-        <section>
-          <currentLanguage.body.default />
+        <Content centred>
+          <BigLogo />
+          <hr />
+        </Content>
 
-          <Content centred>
-            <BigLogo />
-            <hr />
-          </Content>
+        <Content centred>
+          <Socials colour="#d1cec8" />
+        </Content>
+      </section>
+    </main>
+  </div>
+);
 
-          <Content centred>
-            <Socials colour="#d1cec8" />
-          </Content>
-        </section>
-      </main>
-    </div>
-  );
-};
-
-export default Index;
+export default withLanguages(Index);

--- a/pages/progress.jsx
+++ b/pages/progress.jsx
@@ -229,9 +229,9 @@ const ProgressRowItem = (props) => {
   }
 };
 
-const Progress = ({ items, currentLanguage, flags }) => (
+const Progress = ({ items }) => (
   <div className="container">
-    <HeadContent flags={flags} currentLanguage={currentLanguage} title="Homepage" />
+    <HeadContent title="Homepage" />
 
     <main>
       <Content>

--- a/pages/progress.jsx
+++ b/pages/progress.jsx
@@ -12,7 +12,7 @@ import { Content, Paragraph } from '../components/Typography';
 import Pull from '../components/icons/Pull';
 import Issue from '../components/icons/Issue';
 
-import { useLanguages } from '../components/languages';
+import { withLanguages } from '../components/languages';
 
 const DEV = process.env.NODE_ENV !== 'production';
 const ADDRESS = DEV ? 'http://localhost:3000' : 'https://www.open.mp';
@@ -229,27 +229,24 @@ const ProgressRowItem = (props) => {
   }
 };
 
-const Progress = ({ items }) => {
-  const [currentLanguage, flags] = useLanguages();
+const Progress = ({ items, currentLanguage, flags }) => (
+  <div className="container">
+    <HeadContent flags={flags} currentLanguage={currentLanguage} title="Homepage" />
 
-  return (
-    <div className="container">
-      <HeadContent flags={flags} selected={currentLanguage.name} title="Homepage" />
+    <main>
+      <Content>
+        <Paragraph>
+          Below is a progress report of the state of recent issues and pull requests.
+        </Paragraph>
 
-      <main>
-        <Content>
-          <Paragraph>
-            Below is a progress report of the state of recent issues and pull requests.
-          </Paragraph>
+        {items.map(reHydrateDates).map((value, index) => {
+          return <ProgressRowItem key={value.id} {...value} />;
+        })}
+      </Content>
+    </main>
+  </div>
+);
 
-          {items.map(reHydrateDates).map((value, index) => {
-            return <ProgressRowItem key={value.id} {...value} />;
-          })}
-        </Content>
-      </main>
-    </div>
-  );
-};
 Progress.getInitialProps = async () => {
   const res = await fetch(`${ADDRESS}/api/progress`);
   const data = await res.json();
@@ -304,4 +301,4 @@ Progress.getInitialProps = async () => {
   };
 };
 
-export default Progress;
+export default withLanguages(Progress);


### PR DESCRIPTION
> Just wanted to see if it's possible with Next.js. Sadly I wasn't able to figure out a way to do the same for i18n without introducing some per-page boilerplate.

I managed to figure out a way to do it while keeping the amount of per-page boilerplate around the same level.

I wonder how React contexts work with SSR and Next.js, maybe I could even do this without having to explicitly pass `currentLanguage` and `flags` to `HeadContent` on every page...

Edit: ~~Not possible, at least in the way I had in mind.~~ Or maybe...